### PR TITLE
[Fix] Clone3 hooking bug fix

### DIFF
--- a/src/intercept.c
+++ b/src/intercept.c
@@ -675,7 +675,8 @@ intercept_routine(struct context *context)
 		 * the clone_child_intercept_routine instead, executing
 		 * it on the new child threads stack, then returns to libc.
 		 */
-		if (desc.nr == SYS_clone && desc.args[1] != 0)
+		if ((desc.nr == SYS_clone || desc.nr == SYS_clone3) &&
+			desc.args[1] != 0)
 			return (struct wrapper_ret){
 				.rax = context->rax, .rdx = 2 };
 		else


### PR DESCRIPTION
This patch fixes clone3 syscall hooking in ubuntu 22.04. Without this patch, some APIs using clone3 (e.g., pthread_create) will cause a segmentatil fault.

Signed-off-by: Dongju Chae <dongju.chae@mangoboost.io>